### PR TITLE
change package name

### DIFF
--- a/src/main/scala/org/apache/pekko/persistence/inmemory/package.scala
+++ b/src/main/scala/org/apache/pekko/persistence/inmemory/package.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.apache.pekko.persistence
+package io.github.alstanchev.pekko.persistence
 
 import org.apache.pekko.persistence.inmemory.util.UUIDs
 


### PR DESCRIPTION
Thanks for creating this project and publishing a jar.

You haven't set it up so that issues can be logged against this project. I'm creating this dummy Pull Request to report the issue instead.

You should not call your packages `org.apache.pekko`. This is something that only the owners of the pekko.apache.org domain name should do. It is going to confuse users of this project. Many of them will think that the Apache Pekko project have something to do with this project. I am a member of the Apache Pekko project and I respectfully request that you desist from incorrectly using the package name.