### PR TITLE
Update to work with pekko 1.0.3

### DIFF
--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -4,7 +4,7 @@ import com.typesafe.sbt.SbtScalariform
 import scalariform.formatter.preferences.{AlignSingleLineCaseStatements, DanglingCloseParenthesis, DoubleIndentConstructorArguments, Preserve}
 
 object ProjectSettings extends AutoPlugin {
-  final val PekkoV = "1.0.1"
+  final val PekkoV = "1.0.3"
   final val scala212V = "2.12.18"
   final val scala213V = "2.13.11"
   final val scalaV = scala213V

--- a/src/main/scala/io/github/alstanchev/pekko/persistence/inmemory/query/scaladsl/InMemoryReadJournal.scala
+++ b/src/main/scala/io/github/alstanchev/pekko/persistence/inmemory/query/scaladsl/InMemoryReadJournal.scala
@@ -83,7 +83,7 @@ class InMemoryReadJournal(config: Config, journal: ActorRef)(implicit val system
       .mapConcat(identity)
 
   override def persistenceIds(): Source[String, NotUsed] =
-    Source.repeat(0).flatMapConcat(_ => Source.tick(refreshInterval, 0.seconds, 0).take(1).flatMapConcat(_ => currentPersistenceIds()))
+    Source.repeat(0).flatMapConcat(_ => Source.tick(refreshInterval, refreshInterval, 0).take(1).flatMapConcat(_ => currentPersistenceIds()))
       .statefulMapConcat[String] { () =>
         var knownIds = Set.empty[String]
 
@@ -112,7 +112,7 @@ class InMemoryReadJournal(config: Config, journal: ActorRef)(implicit val system
       from match {
         case x if x > toSequenceNr => Future.successful(None)
         case _ =>
-          Source.tick(refreshInterval, 0.seconds, 0).take(1).flatMapConcat(_ =>
+          Source.tick(refreshInterval, refreshInterval, 0).take(1).flatMapConcat(_ =>
             currentEventsByPersistenceId(persistenceId, from, toSequenceNr)
               .take(maxBufferSize)).runWith(Sink.seq).map { xs =>
             val newFromSeqNr = nextFromSeqNr(xs)
@@ -147,7 +147,7 @@ class InMemoryReadJournal(config: Config, journal: ActorRef)(implicit val system
     }.mapConcat(identity)
 
   // ticker
-  val ticker = Source.tick(refreshInterval, 0.seconds, 0).take(1)
+  val ticker = Source.tick(refreshInterval, refreshInterval, 0).take(1)
 
   //
   // deserialization

--- a/src/test/scala/org/apache/pekko/persistence/inmemory/query/QueryTestSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/inmemory/query/QueryTestSpec.scala
@@ -142,7 +142,7 @@ abstract class QueryTestSpec(config: String = "application.conf") extends TestSp
         case WriteMessageSuccess(PersistentImpl(payload, `seqNo`, `pid`, _, _, `sender`, `writerUuid`, timestamp, metadata), _) =>
           val id = s"a-$seqNo"
           payload should matchPattern {
-            case `id` =>
+            case `id`            =>
             case Tagged(`id`, _) =>
           }
         //          println(s"==> written '$payload', for pid: '$pid', seqNo: '$seqNo'")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "1.1.0"
+version := "1.1.1-SNAPSHOT"


### PR DESCRIPTION
Is reported in issue #10, the scheduler isn't allowed to work with a 0 seconds interval.
This update uses the refreshInterval instead. 